### PR TITLE
feat: highlight html

### DIFF
--- a/src/fmt/cli/kast_fmt_cli.ml
+++ b/src/fmt/cli/kast_fmt_cli.ml
@@ -1,30 +1,64 @@
 open Std
 open Kast_util
+open Kast_highlight
 module Parser = Kast_parser
 
 module Args = struct
-  type args = { path : path }
+  type args = {
+    path : path;
+    hl_output : Kast_highlight.output option;
+  }
+
   type t = args
 
   let parse : string list -> args = function
-    | [] -> { path = Stdin }
-    | [ path ] -> { path = File path }
-    | first :: _rest -> fail "unexpected arg %S" first
+    (* stdin, no --highlight specified *)
+    | [] -> { path = Stdin; hl_output = Some Term }
+    (* file, no --highlight specified *)
+    | [ path ] -> { path = File path; hl_output = Some Term }
+    (* stdin, --highlight specified *)
+    | [ "--highlight"; "none" ] -> { path = Stdin; hl_output = None }
+    | [ "--highlight"; "html" ] -> { path = Stdin; hl_output = Some Html }
+    | [ "--highlight"; ("term" | "terminal") ] ->
+        { path = Stdin; hl_output = Some Term }
+    | [ "--highlight"; output ] ->
+        fail
+          "Unexpected highlight output '%S', only 'html', 'term' or 'none' are allowed"
+          output
+    (* file, --highlight specified *)
+    | [ "--highlight"; "none"; path ] | [ path; "--highlight"; "none" ] ->
+        { path = File path; hl_output = None }
+    | [ "--highlight"; "html"; path ] | [ path; "--highlight"; "html" ] ->
+        { path = File path; hl_output = Some Html }
+    | [ "--highlight"; ("term" | "terminal"); path ]
+    | [ path; "--highlight"; ("term" | "terminal") ] ->
+        { path = File path; hl_output = Some Term }
+    | [ "--highlight"; output; _ ] ->
+        fail
+          "Unexpected highlight output '%S', only 'html', 'term' or 'none' are allowed"
+          output
+    | first :: _rest ->
+        fail "Unexpected arg %S, expecting filename or option --highlight" first
 end
 
 let run : Args.t -> unit =
- fun { path } ->
+ fun { path; hl_output } ->
   let source = Source.read path in
   let ruleset = Kast_default_syntax.ruleset in
   let parsed = Parser.parse source ruleset in
   parsed |> Kast_fmt.format Format.str_formatter;
   let formatted = Format.flush_str_formatter () in
-  let do_highlight = true in
-  if do_highlight then
-    let parsed =
-      Parser.parse
-        { contents = formatted; filename = Special "formatted" }
-        ruleset
-    in
-    Kast_highlight.print Format.std_formatter parsed
-  else Format.printf "%s" formatted
+  match hl_output with
+  | Some output ->
+      let parsed =
+        Parser.parse
+          { contents = formatted; filename = Special "formatted" }
+          ruleset
+      in
+      let highlight_print =
+        match output with
+        | Term -> (module Term : Output)
+        | Html -> (module Html : Output)
+      in
+      Kast_highlight.print highlight_print Format.std_formatter parsed
+  | None -> Format.printf "%s" formatted

--- a/src/highlight/cli/kast_highlight_cli.ml
+++ b/src/highlight/cli/kast_highlight_cli.ml
@@ -1,21 +1,41 @@
 open Std
 open Kast_util
+open Kast_highlight
 module Lexer = Kast_lexer
 module Parser = Kast_parser
 
 module Args = struct
-  type args = { path : path }
+  type args = {
+    path : path;
+    output : output;
+  }
+
   type t = args
 
   let parse : string list -> args = function
-    | [] -> { path = Stdin }
-    | [ path ] -> { path = File path }
-    | first :: _rest -> fail "Unexpected arg %S" first
+    (* stdin *)
+    | [] -> { path = Stdin; output = Term }
+    | [ "--html" ] -> { path = Stdin; output = Html }
+    | [ ("--term" | "--terminal") ] -> { path = Stdin; output = Term }
+    (* file *)
+    | [ path ] -> { path = File path; output = Term }
+    | [ "--html"; path ] | [ path; "--html" ] ->
+        { path = File path; output = Html }
+    | [ ("--term" | "--terminal"); path ] | [ path; ("--term" | "--terminal") ]
+      ->
+        { path = File path; output = Term }
+    | _ :: first :: _rest ->
+        fail "Unexpected arg %S, expecting --html or --term" first
 end
 
 let run : Args.t -> unit =
- fun { path } ->
+ fun { path; output } ->
   let source = Source.read path in
   let lexer = Lexer.init Lexer.default_rules source in
   let parsed = Parser.parse_with_lexer lexer Kast_default_syntax.ruleset in
-  Kast_highlight.print Format.std_formatter parsed
+  let print =
+    match output with
+    | Term -> (module Term : Output)
+    | Html -> (module Html : Output)
+  in
+  Kast_highlight.print print Format.std_formatter parsed

--- a/src/highlight/kast_highlight.ml
+++ b/src/highlight/kast_highlight.ml
@@ -10,72 +10,187 @@ type printer = {
   mutable position : position;
 }
 
-let print_char printer c =
-  printer.position <- Position.advance c printer.position;
-  fprintf printer.fmt "%c" c
+type output =
+  | Term
+  | Html
 
-(* TODO actual whitespace tokens? *)
-let move_to (printer : printer) (position : position) : unit =
-  while printer.position.line < position.line do
-    print_char printer '\n'
-  done;
-  while printer.position.column < position.column do
-    print_char printer ' '
-  done
+module type Output = sig
+  val initialize : printer -> unit
+  val finalize : printer -> unit
+  val print_char : printer -> char -> unit
+  val move_to : printer -> position -> unit
+  val print_comment : printer -> Token.comment -> unit
+  val print_keyword : printer -> Token.Shape.t -> unit
+  val print_syntax_part : printer -> Token.Shape.t -> unit
+  val print_value : printer -> Token.Shape.t -> unit
+end
 
-let print_token (printer : printer) (f : printer -> Token.Shape.t -> unit)
-    (token : Token.t) : unit =
-  move_to printer token.span.start;
-  f printer token.shape;
-  printer.position <- token.span.finish
+(* Highlight for a terminal *)
+module Term : Output = struct
+  let initialize = fun _ -> ()
+  let finalize = fun _ -> ()
 
-let print_comment (printer : printer) (comment : Token.comment) : unit =
-  move_to printer comment.span.start;
-  fprintf printer.fmt "@{<gray>%s@}" comment.shape.raw;
-  printer.position <- comment.span.finish
+  let print_char printer c =
+    printer.position <- Position.advance c printer.position;
+    fprintf printer.fmt "%c" c
 
-let print_keyword printer (token : Token.Shape.t) =
-  match Token.Shape.raw token with
-  | Some raw -> fprintf printer.fmt "@{<magenta>%s@}" raw
-  | None -> ()
+  (* TODO actual whitespace tokens? *)
+  let move_to (printer : printer) (position : position) : unit =
+    while printer.position.line < position.line do
+      print_char printer '\n'
+    done;
+    while printer.position.column < position.column do
+      print_char printer ' '
+    done
 
-let print_syntax_part printer (token : Token.Shape.t) =
-  match Token.Shape.raw token with
-  | Some raw -> fprintf printer.fmt "@{<yellow>%s@}" raw
-  | None -> ()
+  let print_comment (printer : printer) (comment : Token.comment) : unit =
+    move_to printer comment.span.start;
+    fprintf printer.fmt "@{<gray>%s@}" comment.shape.raw;
+    printer.position <- comment.span.finish
 
-let print_value printer (token : Token.Shape.t) =
-  let fmt = printer.fmt in
-  match token with
-  | Ident { raw; _ } -> fprintf fmt "%s" raw
-  | String { raw; _ } -> fprintf fmt "@{<green>%s@}" raw
-  | Number { raw; _ } -> fprintf fmt "@{<italic>%s@}" raw
-  | Punct { raw; _ } -> fprintf fmt "%s" raw
-  | Comment _ -> unreachable "<comment> value??"
-  | Eof -> unreachable "<eof> value??"
+  let print_keyword printer (token : Token.Shape.t) =
+    match Token.Shape.raw token with
+    | Some raw -> fprintf printer.fmt "@{<magenta>%s@}" raw
+    | None -> ()
 
-let rec print_ast (printer : printer) (ast : Ast.t) : unit =
-  match ast.shape with
-  | Simple { comments_before; token } ->
-      comments_before |> List.iter (print_comment printer);
-      print_token printer print_value token
-  | Complex { parts; _ } ->
-      parts
-      |> List.iter (function
-           | Ast.Value ast -> print_ast printer ast
-           | Ast.Keyword token -> print_token printer print_keyword token
-           | Ast.Comment comment -> print_comment printer comment)
-  | Syntax { tokens; value_after; _ } -> (
-      tokens |> List.iter (print_token printer print_syntax_part);
-      match value_after with
-      | None -> ()
-      | Some value -> print_ast printer value)
+  let print_syntax_part printer (token : Token.Shape.t) =
+    match Token.Shape.raw token with
+    | Some raw -> fprintf printer.fmt "@{<yellow>%s@}" raw
+    | None -> ()
 
-let print (fmt : formatter) ({ ast; trailing_comments; eof } : Parser.result) :
-    unit =
+  let print_value printer (token : Token.Shape.t) =
+    let fmt = printer.fmt in
+    match token with
+    | Ident { raw; _ } -> fprintf fmt "%s" raw
+    | String { raw; _ } -> fprintf fmt "@{<green>%s@}" raw
+    | Number { raw; _ } -> fprintf fmt "@{<italic>%s@}" raw
+    | Punct { raw; _ } -> fprintf fmt "%s" raw
+    | Comment _ -> unreachable "<comment> value??"
+    | Eof -> unreachable "<eof> value??"
+end
+
+(* Highlight as HTML *)
+module Html : Output = struct
+  let initialize { fmt; _ } =
+    [
+      "<style>";
+      (*helix onedark theme*)
+      "    /*fg colors*/";
+      "    code .fg-none    { }";
+      "    code .fg-white   { color: #ABB2BF; }";
+      "    code .fg-grey    { color: #5C6370; }";
+      "    code .fg-green   { color: #98C379; }";
+      "    code .fg-yellow  { color: #E5C07B; }";
+      "    code .fg-purple  { color: #C678DD; }";
+      "    code .fg-magenta { color: #C678DD; }";
+      "";
+      (*currently unused: *)
+      "    code .fg-blue { color: #61AFEF; }";
+      "    code .fg-red { color: #E06C75; }";
+      "    code .fg-gold { color: #D19A66; }";
+      "    code .fg-cyan { color: #56B6C2; }";
+      "    code .fg-black { color: #282C34; }";
+      "    code .fg-light-black { color: #2C323C; }";
+      "    code .fg-gray { color: #3E4452; }";
+      "    code .fg-faint-gray { color: #3B4048; }";
+      "    code .fg-light-gray { color: #5C6370; }";
+      "    code .fg-linenr { color: #4B5263; }";
+      "";
+      "    /*bg colors*/";
+      "    code .bg-black   { background-color: #282C34; }";
+      "    pre.bg-black     { background-color: #282C34; }";
+      "";
+      "    /*decoration*/";
+      "    code .font-italic   { font-style: italic; }";
+      "</style>\n";
+    ]
+    |> List.map (fprintln fmt)
+    |> ignore;
+    fprintf fmt "<pre class=\"bg-black\"><code>"
+
+  let finalize { fmt; _ } = fprintln fmt "</code></pre>"
+
+  let print_str printer s color =
+    fprintf printer "<span class=\"fg-%s\">%s</span>" color s
+
+  let print_str_italic printer s color =
+    fprintf printer "<span class=\"fg-%s font-italic\">%s</span>" color s
+
+  let print_char printer c =
+    printer.position <- Position.advance c printer.position;
+    fprintf printer.fmt "<span class=\"fg-none\">%c</span>" c
+
+  (* TODO actual whitespace tokens? *)
+  let move_to (printer : printer) (position : position) : unit =
+    while printer.position.line < position.line do
+      print_char printer '\n'
+    done;
+    while printer.position.column < position.column do
+      print_char printer ' '
+    done
+
+  let print_comment (printer : printer) (comment : Token.comment) : unit =
+    move_to printer comment.span.start;
+    print_str printer.fmt comment.shape.raw "grey";
+    printer.position <- comment.span.finish
+
+  let print_keyword printer (token : Token.Shape.t) =
+    match Token.Shape.raw token with
+    | Some raw -> print_str printer.fmt raw "magenta"
+    | None -> ()
+
+  let print_syntax_part printer (token : Token.Shape.t) =
+    match Token.Shape.raw token with
+    | Some raw -> print_str printer.fmt raw "yellow"
+    | None -> ()
+
+  let print_value printer (token : Token.Shape.t) =
+    let fmt = printer.fmt in
+    match token with
+    | Ident { raw; _ } -> print_str fmt raw "white"
+    | String { raw; _ } -> print_str fmt raw "green"
+    | Number { raw; _ } -> print_str_italic fmt raw "white"
+    | Punct { raw; _ } -> print_str fmt raw "white"
+    | Comment _ -> unreachable "<comment> value??"
+    | Eof -> unreachable "<eof> value??"
+end
+
+module Common (Output : Output) = struct
+  let print_token (printer : printer) (f : printer -> Token.Shape.t -> unit)
+      (token : Token.t) : unit =
+    Output.move_to printer token.span.start;
+    f printer token.shape;
+    printer.position <- token.span.finish
+
+  let rec print_ast (printer : printer) (ast : Ast.t) : unit =
+    match ast.shape with
+    | Simple { comments_before; token } ->
+        comments_before |> List.iter (Output.print_comment printer);
+        print_token printer Output.print_value token
+    | Complex { parts; _ } ->
+        parts
+        |> List.iter (function
+             | Ast.Value ast -> print_ast printer ast
+             | Ast.Keyword token ->
+                 print_token printer Output.print_keyword token
+             | Ast.Comment comment -> Output.print_comment printer comment)
+    | Syntax { tokens; value_after; _ } -> (
+        tokens |> List.iter (print_token printer Output.print_syntax_part);
+        match value_after with
+        | None -> ()
+        | Some value -> print_ast printer value)
+end
+
+let print (module Output : Output) (fmt : formatter)
+    ({ ast; trailing_comments; eof } : Parser.result) : unit =
   let printer = { fmt; position = Position.beginning } in
+  Output.initialize printer;
   (match ast with
-  | Some ast -> print_ast printer ast
+  | Some ast ->
+      let module Print = Common (Output) in
+      Print.print_ast printer ast
   | None -> ());
-  trailing_comments |> List.iter (fun comment -> print_comment printer comment);
-  move_to printer eof
+  trailing_comments
+  |> List.iter (fun comment -> Output.print_comment printer comment);
+  Output.move_to printer eof;
+  Output.finalize printer


### PR DESCRIPTION
- abstract Output with impls for Term and Html
- option `--highlight none/term/html` for `kast fmt` cli
- option `--html/--term` for `kast highlight` cli