### PR TITLE
add natives `std.net.tcp.(bind, listen, accept, close)`

### DIFF
--- a/examples/tcp-client.ks
+++ b/examples/tcp-client.ks
@@ -1,0 +1,16 @@
+use std.net.tcp;
+use std.String;
+
+# connect
+let stream = tcp.TcpStream.connect "127.0.0.1:1234";
+
+# write to stream
+tcp.TcpStream.write (
+    &stream,
+    &"Hello from Kast\n"
+);
+std.io.print "Waiting for reply from server";
+
+# read from stream
+let response = tcp.TcpStream.read_line &stream;
+std.io.print <| "Server said:\n" + response;

--- a/examples/tcp-server.ks
+++ b/examples/tcp-server.ks
@@ -1,0 +1,21 @@
+use std.net.tcp;
+use std.String;
+
+# connect
+let stream = tcp.TcpStream.bind "127.0.0.1:1234";
+
+# start listening
+tcp.TcpStream.listen (&stream, 5);
+
+# accept one client connection
+let client = tcp.TcpStream.accept (&stream, .close_on_exec = false);
+std.io.print <| "Connected to client " + client.addr;
+
+let response = tcp.TcpStream.read_line &client.stream;
+std.io.print <| "Client said:\n" + response;
+
+# close client connection
+tcp.TcpStream.close client.stream;
+
+# close server
+tcp.TcpStream.close stream;

--- a/src/interpreter/natives.ml
+++ b/src/interpreter/natives.ml
@@ -428,10 +428,11 @@ let init_natives () =
                     read_loop ();
                     V_String !result |> Value.inferred ~span
                 | _ ->
-                    Error.error caller "net.tcp.connect expected the &tcpstream";
+                    Error.error caller
+                      "net.tcp.read_line expected the &tcpstream";
                     V_Error |> Value.inferred ~span)
             | _ ->
-                Error.error caller "net.tcp.connect expected the &tcpstream";
+                Error.error caller "net.tcp.read_line expected the &tcpstream";
                 V_Error |> Value.inferred ~span)
       in
       let write =
@@ -481,10 +482,154 @@ let init_natives () =
                     Error.error caller "net.tcp.connect expected string arg";
                     V_Error |> Value.inferred ~span)
             | _ ->
-                Error.error caller "wrong type???";
+                Error.error caller "net.tcp.connect returns type TcpStream";
                 V_Error |> Value.inferred ~span)
       in
-      [ write; connect; read_line ]
+      let bind =
+        native_fn "net.tcp.bind" (fun ty ~caller ~state:_ arg : value ->
+            match Ty.await_inferred ty.result with
+            | T_Opaque result_ty -> (
+                match arg |> Value.await_inferred with
+                | V_String uri ->
+                    println "Binding to %S" uri;
+                    let host, port =
+                      match String.split_on_char ':' uri with
+                      | [ host; port ] -> (host, port)
+                      | _ -> failwith "Expected host:port"
+                    in
+                    let addr =
+                      match Unix.getaddrinfo host port [] with
+                      | addr :: _ -> addr
+                      | [] -> failwith "could not resolve addr"
+                    in
+                    (* Create socket *)
+                    let socket : tcp_stream =
+                      Unix.socket addr.ai_family addr.ai_socktype
+                        addr.ai_protocol
+                    in
+                    (* Bind socket *)
+                    Unix.bind socket addr.ai_addr;
+                    V_Opaque { ty = result_ty; value = Obj.repr socket }
+                    |> Value.inferred ~span
+                | _ ->
+                    Error.error caller "net.tcp.bind expected string arg";
+                    V_Error |> Value.inferred ~span)
+            | _ ->
+                Error.error caller "net.tcp.bind returns type TcpStream";
+                V_Error |> Value.inferred ~span)
+      in
+      let listen =
+        native_fn "net.tcp.listen" (fun _ty ~caller:_ ~state:_ arg : value ->
+            let args = arg |> Value.expect_tuple |> Option.get in
+            let socket, max_pending = args.tuple |> Tuple.unwrap_unnamed2 in
+            let socket : tcp_stream =
+              socket.place |> Common.claim ~span |> Value.expect_ref
+              |> Option.get |> Common.read_place ~span |> Value.expect_opaque
+              |> Option.get
+            in
+            let max_pending =
+              max_pending.place |> Common.claim ~span |> Value.expect_int32
+              |> Option.get
+            in
+            (* Native call *)
+            Unix.listen socket (Int32.to_int max_pending);
+            V_Unit |> Value.inferred ~span)
+      in
+      let accept =
+        native_fn "net.tcp.accept" (fun ty ~caller ~state:_ arg : value ->
+            match Ty.await_inferred ty.result with
+            (* Get return type *)
+            | T_Tuple ({ tuple = result_ty_field; _ } as result_ty) -> (
+                (* Destructure return type tuple *)
+                let stream_ty, addr_ty =
+                  Tuple.unwrap_named2 [ "stream"; "addr" ] result_ty_field
+                in
+                match
+                  ( stream_ty.ty |> Ty.await_inferred,
+                    addr_ty.ty |> Ty.await_inferred )
+                with
+                (* Assert .stream :: TcpStream & .addr :: String)` *)
+                | T_Opaque client_stream_ty, T_String ->
+                    (* Destructure input argument as expected type *)
+                    let args = arg |> Value.expect_tuple |> Option.get in
+                    let socket, close_on_exec =
+                      args.tuple |> Tuple.unwrap_unnamed2
+                    in
+                    let socket : tcp_stream =
+                      socket.place |> Common.claim ~span |> Value.expect_ref
+                      |> Option.get |> Common.read_place ~span
+                      |> Value.expect_opaque |> Option.get
+                    in
+                    let close_on_exec =
+                      close_on_exec.place |> Common.claim ~span
+                      |> Value.expect_bool |> Option.get
+                    in
+                    (* Native call *)
+                    let client_stream, client_addr =
+                      Unix.accept ?cloexec:(Some close_on_exec) socket
+                    in
+                    let client_addr =
+                      match client_addr with
+                      | Unix.ADDR_UNIX str -> str
+                      | Unix.ADDR_INET (addr, port) ->
+                          Unix.string_of_inet_addr addr
+                          ^ ":" ^ string_of_int port
+                    in
+                    (* Make return data *)
+                    let client_stream_value : Types.value_tuple_field =
+                      {
+                        place =
+                          V_Opaque
+                            {
+                              ty = client_stream_ty;
+                              value = Obj.repr client_stream;
+                            }
+                          |> Value.inferred ~span |> Place.init;
+                        span;
+                        ty_field = stream_ty;
+                      }
+                    in
+                    let client_addr_value : Types.value_tuple_field =
+                      {
+                        place =
+                          V_String client_addr |> Value.inferred ~span
+                          |> Place.init;
+                        span;
+                        ty_field = addr_ty;
+                      }
+                    in
+                    V_Tuple
+                      {
+                        ty = result_ty;
+                        tuple =
+                          Tuple.of_list
+                            [
+                              (Some "stream", client_stream_value);
+                              (Some "addr", client_addr_value);
+                            ];
+                      }
+                    |> Value.inferred ~span
+                | _ ->
+                    Error.error caller
+                      "net.tcp.accept returns (.stream :: TcpStream, .addr :: String)";
+                    V_Error |> Value.inferred ~span)
+            | _ ->
+                Error.error caller "net.tcp.accept returns tuple";
+                V_Error |> Value.inferred ~span)
+      in
+      let close =
+        native_fn "net.tcp.close" (fun _ty ~caller ~state:_ arg : value ->
+            match arg |> Value.await_inferred with
+            | V_Opaque { ty = _; value = socket } ->
+                let socket : tcp_stream = Obj.obj socket in
+                (* Native call *)
+                Unix.close socket;
+                V_Unit |> Value.inferred ~span
+            | _ ->
+                Error.error caller "net.tcp.read_line expected the &tcpstream";
+                V_Error |> Value.inferred ~span)
+      in
+      [ write; connect; read_line; bind; listen; accept; close ]
     in
     tcp
   in

--- a/std/net/tcp.ks
+++ b/std/net/tcp.ks
@@ -1,15 +1,38 @@
 module:
 
+# A TCP stream file descriptor
 const TcpStream = @opaque_type;
 
-const connect = (addr :: String) -> TcpStream => cfg_if (
-    | target.name == "interpreter" => (@native "net.tcp.connect") addr
-);
-
-const read_line = (stream :: &TcpStream) -> String => cfg_if (
-    | target.name == "interpreter" => (@native "net.tcp.read_line") stream
-);
-
-const write = (stream :: &TcpStream, data :: &String) -> () => cfg_if (
-    | target.name == "interpreter" => (@native "net.tcp.write") (stream, data)
+impl TcpStream as module = (
+    module:
+    const connect = (addr :: String) -> TcpStream => cfg_if (
+        | target.name == "interpreter" => (@native "net.tcp.connect") addr
+    );
+    
+    const read_line = (stream :: &TcpStream) -> String => cfg_if (
+        | target.name == "interpreter" => (@native "net.tcp.read_line") stream
+    );
+    
+    const write = (stream :: &TcpStream, data :: &String) -> () => cfg_if (
+        | target.name == "interpreter" => (@native "net.tcp.write") (stream, data)
+    );
+    
+    const bind = (addr :: String) -> TcpStream => cfg_if (
+        | target.name == "interpreter" => (@native "net.tcp.bind") addr
+    );
+    
+    const listen = (stream :: &TcpStream, max_pending :: Int32) -> () => cfg_if (
+        | target.name == "interpreter" => (@native "net.tcp.listen") (stream, max_pending)
+    );
+    
+    const accept = (stream :: &TcpStream, .close_on_exec :: Bool) -> (
+        .stream :: TcpStream,
+        .addr :: String
+    ) => cfg_if (
+        | target.name == "interpreter" => (@native "net.tcp.accept") (stream, close_on_exec)
+    );
+    
+    const close = (stream :: TcpStream) -> () => cfg_if (
+        | target.name == "interpreter" => (@native "net.tcp.close") stream
+    );
 );

--- a/workspace.ks
+++ b/workspace.ks
@@ -21,4 +21,6 @@
     "examples/refs.ks",
     "examples/lots-of-math.ks",
     "examples/monad.ks",
+    "examples/tcp-client.ks",
+    "examples/tcp-server.ks",
 )


### PR DESCRIPTION
- also moved `connect`, `read_line` & `write` as impl methods of `TcpStream`
- also added examples for TCP client and TCP server