### PR TITLE
feat: LSP uses syntax-files read at compile-time

### DIFF
--- a/src/lsp/_lib.ks
+++ b/src/lsp/_lib.ks
@@ -85,15 +85,17 @@ const Lsp = (
     const run = (arg :: CliArgs.t) => (
         (@current Stdout).color = false;
         (@current Stderr).color = false;
-        let get_syntax = ruleset_path => (
-            let mut lexer = Lexer.new(Source.read(SourcePath.file(ruleset_path)));
+        const kast_syntax_file :: Source = Source.read(SourcePath.file("tests/syntax/kast.ks"));
+        const minikast_syntax_file :: Source = Source.read(SourcePath.file("src/mini/syntax.ks"));
+        let get_syntax = source => (
+            let mut lexer = Lexer.new(source);
             let mut token_stream = TokenStream.from_fn(() => Lexer.next(&mut lexer));
             SyntaxParser.parse_syntax_ruleset(&mut token_stream)
         );
         let mut state :: State = {
             .@"syntax" = {
-                .kast = get_syntax("tests/syntax/kast.ks"),
-                .minikast = get_syntax("src/mini/syntax.ks"),
+                .kast = get_syntax(kast_syntax_file),
+                .minikast = get_syntax(minikast_syntax_file),
             },
             .files = OrdMap.new(),
         };


### PR DESCRIPTION
- subcommand lsp uses syntax-files (tests/syntax/kast.ks, src/mini/syntax.ks) that are read to source files at compile-time, letting it be run without those files needing to present at runtime