### PR TITLE
feat: add SyntaxSource for kast, minikast & json

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,9 @@
         filter = inputs.nix-filter.lib;
       in with pkgs; rec {
         mk-kast-js = {
-          kastSyntax ? null,
-          minikastSyntax ? null,
-          jsonSyntax ? null
+          readOnlyKastSyntax ? false,
+          readOnlyMinikastSyntax ? false,
+          readOnlyJsonSyntax ? false
         }: stdenv.mkDerivation {
           name = "kast-js";
           src = filter {
@@ -25,9 +25,9 @@
             include = [ ".justfile" "src" "deps" "std" ];
           };
 
-          READONLY_KAST_SYNTAX = kastSyntax;
-          READONLY_MINIKAST_SYNTAX = minikastSyntax;
-          READONLY_JSON_SYNTAX = jsonSyntax;
+          READONLY_KAST_SYNTAX = if readOnlyKastSyntax then "1" else "";
+          READONLY_MINIKAST_SYNTAX = if readOnlyMinikastSyntax then "1" else "";
+          READONLY_JSON_SYNTAX = if readOnlyJsonSyntax then "1" else "";
 
           buildInputs = [ kast-bootstrap just ];
           buildPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -13,23 +13,33 @@
         pkgs = import inputs.nixpkgs { inherit system overlays; };
         kast-bootstrap = inputs.kast.packages.${system}.default;
         filter = inputs.nix-filter.lib;
-      in with pkgs; {
-        packages = rec {
-          kast-js = stdenv.mkDerivation {
-            name = "kast-js";
-            src = filter {
-              root = ./.;
-              include = [ ".justfile" "src" "deps" "std" ];
-            };
-            buildInputs = [ kast-bootstrap just ];
-            buildPhase = ''
-              KAST_BIN=${kast-bootstrap}/bin/kast just build
-            '';
-            installPhase = ''
-              mkdir $out
-              cp target/kast.mjs $out/kast.mjs
-            '';
+      in with pkgs; rec {
+        mk-kast-js = {
+          kastSyntax ? null,
+          minikastSyntax ? null,
+          jsonSyntax ? null
+        }: stdenv.mkDerivation {
+          name = "kast-js";
+          src = filter {
+            root = ./.;
+            include = [ ".justfile" "src" "deps" "std" ];
           };
+
+          READONLY_KAST_SYNTAX = kastSyntax;
+          READONLY_MINIKAST_SYNTAX = minikastSyntax;
+          READONLY_JSON_SYNTAX = jsonSyntax;
+
+          buildInputs = [ kast-bootstrap just ];
+          buildPhase = ''
+            KAST_BIN="${kast-bootstrap}/bin/kast" just build
+          '';
+          installPhase = ''
+            mkdir $out
+            cp target/kast.mjs $out/kast.mjs
+          '';
+        };
+        packages = rec {
+          kast-js = (mk-kast-js {});
           kast = pkgs.writeShellApplication {
             name = "kast";
             runtimeInputs = [ nodejs ];

--- a/src/cli/common.ks
+++ b/src/cli/common.ks
@@ -1,4 +1,5 @@
 use (import "../diagnostic.ks").*;
+use (import "../syntax_sources.ks").*;
 
 module:
 
@@ -6,7 +7,7 @@ const Common = (
     module:
 
     const Syntax = newtype {
-        .ruleset :: String,
+        .ruleset :: SyntaxSource,
         .ext :: Option.t[String],
     };
 

--- a/src/cli/format.ks
+++ b/src/cli/format.ks
@@ -6,6 +6,7 @@ use (import "../source_path.ks").*;
 use (import "../lexer/_lib.ks").*;
 use (import "../token_stream.ks").*;
 use (import "../syntax_parser.ks").*;
+use (import "../syntax_sources.ks").*;
 use (import "../parser.ks").*;
 use (import "../highlight.ks").*;
 use (import "../format.ks").*;
@@ -21,7 +22,7 @@ const Format = (
         module:
 
         const t = newtype {
-            .ruleset :: Option.t[String],
+            .ruleset :: Option.t[SyntaxSource],
             .paths :: ArrayList.t[String],
             .highlight :: Option.t[Highlight.OutputMode],
             .inplace :: Bool,
@@ -40,7 +41,7 @@ const Format = (
                 let arg = std.sys.argv_at(i);
                 if arg == "--ruleset" and &@"syntax" |> Option.is_none then (
                     @"syntax" = :Some {
-                        .ruleset = std.sys.argv_at(i + 1),
+                        .ruleset = :Path std.sys.argv_at(i + 1),
                         .ext = :None,
                     };
                     i += 2;
@@ -76,8 +77,12 @@ const Format = (
     const run = (common_args :: Common.Args.t, args :: Args.t) => (
         # TODO because we mutate ruleset when parsing actually but should not be the case
         let get_ruleset = () => (
-            let ruleset_path = args.ruleset |> Option.unwrap_or("std/syntax.ks");
-            let mut lexer = Lexer.new(Source.read(SourcePath.file(ruleset_path)));
+            let mut lexer = Lexer.new(
+                args.ruleset
+                    # default to kast syntax if ruleset not specified
+                    |> Option.unwrap_or(kast_syntax)
+                    |> SyntaxSource.to_source
+            );
             let mut token_stream = TokenStream.from_fn(() => Lexer.next(&mut lexer));
             SyntaxParser.parse_syntax_ruleset(&mut token_stream)
         );

--- a/src/cli/highlight.ks
+++ b/src/cli/highlight.ks
@@ -6,6 +6,7 @@ use (import "../source_path.ks").*;
 use (import "../lexer/_lib.ks").*;
 use (import "../token_stream.ks").*;
 use (import "../syntax_parser.ks").*;
+use (import "../syntax_sources.ks").*;
 use (import "../parser.ks").*;
 use (import "../highlight.ks").*;
 
@@ -20,7 +21,7 @@ const Highlight = (
         module:
 
         const t = newtype {
-            .ruleset :: Option.t[String],
+            .ruleset :: Option.t[SyntaxSource],
             .paths :: ArrayList.t[String],
             .mode :: root_scope.Highlight.OutputMode,
         };
@@ -37,7 +38,7 @@ const Highlight = (
                 let arg = std.sys.argv_at(i);
                 if arg == "--ruleset" and &@"syntax" |> Option.is_none then (
                     @"syntax" = :Some {
-                        .ruleset = std.sys.argv_at(i + 1),
+                        .ruleset = :Path std.sys.argv_at(i + 1),
                         .ext = :None,
                     };
                     i += 2;
@@ -60,8 +61,12 @@ const Highlight = (
     );
 
     const run = (common_args :: Common.Args.t, args :: Args.t) => (
-        let ruleset_path = args.ruleset |> Option.unwrap_or("std/syntax.ks");
-        let mut lexer = Lexer.new(Source.read(SourcePath.file(ruleset_path)));
+        let mut lexer = Lexer.new(
+            args.ruleset
+                # default to kast syntax if ruleset not specified
+                |> Option.unwrap_or(kast_syntax)
+                |> SyntaxSource.to_source
+        );
         let mut token_stream = TokenStream.from_fn(() => Lexer.next(&mut lexer));
         let ruleset = SyntaxParser.parse_syntax_ruleset(&mut token_stream);
 

--- a/src/cli/mini.ks
+++ b/src/cli/mini.ks
@@ -6,6 +6,7 @@ use (import "../source_path.ks").*;
 use (import "../lexer/_lib.ks").*;
 use (import "../token_stream.ks").*;
 use (import "../syntax_parser.ks").*;
+use (import "../syntax_sources.ks").*;
 use (import "../parser.ks").*;
 use (import "../ast.ks").*;
 use (import "../mini/_lib.ks").*;
@@ -26,8 +27,6 @@ module:
 
 const Mini = (
     module:
-
-    const syntax_ruleset_path = root_scope.Mini.Compiler.ruleset_path();
 
     const Repl = (
         module:
@@ -160,7 +159,7 @@ const Mini = (
 
         const parse = (start_index :: Int32) -> t => (
             let fix_syntax = :Some {
-                .ruleset = syntax_ruleset_path,
+                .ruleset = minikast_syntax,
                 .ext = :Some "mks",
             };
             let mut common = Common.Args.default();

--- a/src/cli/parse.ks
+++ b/src/cli/parse.ks
@@ -6,6 +6,7 @@ use (import "../source_path.ks").*;
 use (import "../lexer/_lib.ks").*;
 use (import "../token_stream.ks").*;
 use (import "../syntax_parser.ks").*;
+use (import "../syntax_sources.ks").*;
 use (import "../parser.ks").*;
 use (import "../ast.ks").*;
 
@@ -18,7 +19,7 @@ const Parse = (
         module:
 
         const t = newtype {
-            .ruleset_path :: Option.t[String],
+            .ruleset :: Option.t[SyntaxSource],
             .paths :: ArrayList.t[String],
         };
 
@@ -36,7 +37,7 @@ const Parse = (
                         Diagnostic.abort("Expected ruleset path");
                     );
                     @"syntax" = :Some {
-                        .ruleset = std.sys.argv_at(i + 1),
+                        .ruleset = :Path std.sys.argv_at(i + 1),
                         .ext = :None,
                     };
                     i += 2;
@@ -46,19 +47,27 @@ const Parse = (
                 i += 1;
             );
             {
-                .ruleset_path = @"syntax" |> Option.map(s => s.ruleset),
+                .ruleset = @"syntax" |> Option.map(s => s.ruleset),
                 .paths,
             }
         );
     );
 
     const run = (common_args :: Common.Args.t, args :: Args.t) => (
-        let ruleset_path = args.ruleset_path |> Option.unwrap_or("std/syntax.ks");
+        let ruleset_path = &args.ruleset
+            |> Option.as_ref
+            |> Option.unwrap_or(&kast_syntax)
+            |> SyntaxSource.path;
         ansi.with_mode(
             :Bold,
             () => (@current Output).write("Parsing syntax rules from " + ruleset_path + "\n\n"),
         );
-        let mut lexer = Lexer.new(Source.read(SourcePath.file(ruleset_path)));
+        let mut lexer = Lexer.new(
+            args.ruleset
+                # default to kast syntax if ruleset not specified
+                |> Option.unwrap_or(kast_syntax)
+                |> SyntaxSource.to_source
+        );
         let mut token_stream = TokenStream.from_fn(() => Lexer.next(&mut lexer));
         let ruleset = SyntaxParser.parse_syntax_ruleset(&mut token_stream);
         let process = (path :: SourcePath) => (

--- a/src/cli/repl.ks
+++ b/src/cli/repl.ks
@@ -7,6 +7,7 @@ use (import "../lexer/_lib.ks").*;
 use (import "../token_stream.ks").*;
 use (import "../syntax_ruleset.ks").*;
 use (import "../syntax_parser.ks").*;
+use (import "../syntax_sources.ks").*;
 use (import "../parser.ks").*;
 use (import "../ast.ks").*;
 use (import "../highlight.ks").*;
@@ -143,8 +144,7 @@ const Repl = (
     );
 
     const run = (common_args :: Common.Args.t, args :: Args.t) => (
-        let ruleset_path = "std/syntax.ks";
-        let mut lexer = Lexer.new(Source.read(SourcePath.file(ruleset_path)));
+        let mut lexer = Lexer.new(kast_syntax |> SyntaxSource.to_source);
         let mut token_stream = TokenStream.from_fn(() => Lexer.next(&mut lexer));
         let ruleset = SyntaxParser.parse_syntax_ruleset(&mut token_stream);
         let eval = (line :: Line) => (

--- a/src/cli/structural_find_and_replace.ks
+++ b/src/cli/structural_find_and_replace.ks
@@ -7,6 +7,7 @@ use (import "../source_path.ks").*;
 use (import "../lexer/_lib.ks").*;
 use (import "../token_stream.ks").*;
 use (import "../syntax_parser.ks").*;
+use (import "../syntax_sources.ks").*;
 use (import "../parser.ks").*;
 use (import "../ast.ks").*;
 use (import "../highlight.ks").*;
@@ -24,7 +25,7 @@ const StructuralFindAndReplace = (
         module:
 
         const t = newtype {
-            .ruleset :: Option.t[String],
+            .ruleset :: Option.t[SyntaxSource],
             .paths :: ArrayList.t[String],
             .pattern :: String,
             .replace :: Option.t[String],
@@ -47,7 +48,7 @@ const StructuralFindAndReplace = (
                 let arg = std.sys.argv_at(i);
                 if arg == "--ruleset" and &@"syntax" |> Option.is_none then (
                     @"syntax" = :Some {
-                        .ruleset = std.sys.argv_at(i + 1),
+                        .ruleset = :Path std.sys.argv_at(i + 1),
                         .ext = :None,
                     };
                     i += 2;
@@ -89,8 +90,12 @@ const StructuralFindAndReplace = (
     );
 
     const run = (common_args :: Common.Args.t, args :: Args.t) => (
-        let ruleset_path = args.ruleset |> Option.unwrap_or("std/syntax.ks");
-        let mut lexer = Lexer.new(Source.read(SourcePath.file(ruleset_path)));
+        let mut lexer = Lexer.new(
+            args.ruleset
+                # default to kast syntax if ruleset not specified
+                |> Option.unwrap_or(kast_syntax)
+                |> SyntaxSource.to_source
+        );
         let mut token_stream = TokenStream.from_fn(() => Lexer.next(&mut lexer));
         let ruleset = SyntaxParser.parse_syntax_ruleset(&mut token_stream);
         let replace_ruleset = match args.replace_ruleset with (

--- a/src/json/_lib.ks
+++ b/src/json/_lib.ks
@@ -11,6 +11,7 @@ use (import "../token_stream.ks").*;
 use (import "../position.ks").*;
 use (import "../syntax_rule.ks").*;
 use (import "../syntax_parser.ks").*;
+use (import "../syntax_sources.ks").*;
 use (import "../ast.ks").*;
 use (import "../parser.ks").*;
 const dep = import "../../deps/json/lib.ks";
@@ -101,9 +102,7 @@ const Json = (
     };
 
     const ruleset = () => (
-        const path = "src/json/syntax.ks";
-        const source = Source.read(SourcePath.file(path));
-        let mut lexer = Lexer.new(source);
+        let mut lexer = Lexer.new(json_syntax |> SyntaxSource.to_source);
         let mut token_stream = TokenStream.from_fn(() => Lexer.next(&mut lexer));
         SyntaxParser.parse_syntax_ruleset(&mut token_stream)
     );

--- a/src/lsp/_lib.ks
+++ b/src/lsp/_lib.ks
@@ -85,8 +85,6 @@ const Lsp = (
     const run = (arg :: CliArgs.t) => (
         (@current Stdout).color = false;
         (@current Stderr).color = false;
-        const kast_syntax_file :: Source = Source.read(SourcePath.file("std/syntax.ks"));
-        const minikast_syntax_file :: Source = Source.read(SourcePath.file("src/mini/syntax.ks"));
         let get_syntax = source => (
             let mut lexer = Lexer.new(source);
             let mut token_stream = TokenStream.from_fn(() => Lexer.next(&mut lexer));
@@ -94,8 +92,8 @@ const Lsp = (
         );
         let mut state :: State = {
             .@"syntax" = {
-                .kast = get_syntax(kast_syntax_file),
-                .minikast = get_syntax(minikast_syntax_file),
+                .kast = get_syntax(kast_syntax |> SyntaxSource.to_source),
+                .minikast = get_syntax(minikast_syntax |> SyntaxSource.to_source),
             },
             .files = OrdMap.new(),
         };

--- a/src/lsp/common.ks
+++ b/src/lsp/common.ks
@@ -7,6 +7,7 @@ use (import "../lexer/_lib.ks").*;
 use (import "../token_stream.ks").*;
 use (import "../syntax_ruleset.ks").*;
 use (import "../syntax_parser.ks").*;
+use (import "../syntax_sources.ks").*;
 use (import "../parser.ks").*;
 use (import "../source.ks").*;
 use (import "../source_path.ks").*;

--- a/src/mini/compiler.ks
+++ b/src/mini/compiler.ks
@@ -11,6 +11,7 @@ use (import "../token_stream.ks").*;
 use (import "../lexer/_lib.ks").*;
 use (import "../syntax_ruleset.ks").*;
 use (import "../syntax_parser.ks").*;
+use (import "../syntax_sources.ks").*;
 use (import "../parser.ks").*;
 use (import "../ast.ks").*;
 use (import "../highlight.ks").*;
@@ -234,12 +235,8 @@ const Compiler = (
         );
     );
 
-    const ruleset_path = () -> String => (
-        "src/mini/syntax.ks"
-    );
-
     const ruleset = () -> SyntaxRuleset.t => (
-        let mut lexer = Lexer.new(Source.read(SourcePath.file(ruleset_path())));
+        let mut lexer = Lexer.new(minikast_syntax |> SyntaxSource.to_source);
         let mut token_stream = TokenStream.from_fn(() => Lexer.next(&mut lexer));
         SyntaxParser.parse_syntax_ruleset(&mut token_stream)
     );

--- a/src/syntax_sources.ks
+++ b/src/syntax_sources.ks
@@ -2,7 +2,10 @@ use (import "./source.ks").*;
 use (import "./source_path.ks").*;
 
 const is_set = (var :: String) => (
-    &std.sys.get_env(var) |> Option.is_some
+    match std.sys.get_env(var) with (
+        | :Some c => String.length(c) > 0
+        | :None => false
+    )
 );
 
 const SyntaxSource = newtype (

--- a/src/syntax_sources.ks
+++ b/src/syntax_sources.ks
@@ -1,0 +1,46 @@
+use (import "./source.ks").*;
+use (import "./source_path.ks").*;
+
+const is_set = (var :: String) => (
+    &std.sys.get_env(var) |> Option.is_some
+);
+
+const SyntaxSource = newtype (
+    # Source that will be read at runtime from a path
+    | :Path String
+    # Source that has already been read at compile-time
+    | :Static Source
+);
+
+impl SyntaxSource as module = (
+    module:
+
+    const new = (path :: String, at_comptime :: Bool) -> SyntaxSource => (
+        if at_comptime then (
+            :Static Source.read(SourcePath.file(path))
+        ) else (
+            :Path path
+        )
+    );
+
+    const to_source = (self :: SyntaxSource) -> Source => (
+        match self with (
+            | :Path path => Source.read(SourcePath.file(path))
+            | :Static source => source
+        )
+    );
+
+    const path = (self :: &SyntaxSource) -> String => (
+        match self with (
+            | &(:Path path) => path
+            | &(:Static ref source) => source^.path |> to_string
+        )
+    );
+);
+
+module:
+
+const SyntaxSource = SyntaxSource;
+const kast_syntax = SyntaxSource.new("std/syntax.ks", is_set("READONLY_KAST_SYNTAX"));
+const minikast_syntax = SyntaxSource.new("src/mini/syntax.ks", is_set("READONLY_MINIKAST_SYNTAX"));
+const json_syntax = SyntaxSource.new("src/json/syntax.ks", is_set("READONLY_JSON_SYNTAX"));


### PR DESCRIPTION
- type SyntaxSource which is either a path `String` or a comptime loaded `Source`
- const `kast_syntax` which is comptime loaded if env-var `READONLY_KAST_SYNTAX` is set
- const `minikast_syntax` which is comptime loaded if env-var `READONLY_MINIKAST_SYNTAX` is set
- const `json_syntax` which is comptime loaded if env-var `READONLY_JSON_SYNTAX` is set